### PR TITLE
fix(wallet_list): add SafeArea to wallet list

### DIFF
--- a/lib/widgets/wallet_list.dart
+++ b/lib/widgets/wallet_list.dart
@@ -212,19 +212,21 @@ class WalletListState extends State<WalletList> {
 
   @override
   Widget build(BuildContext context) {
-    return ListView(padding: EdgeInsets.all(8), children: [
-      Row(
-          mainAxisAlignment: MainAxisAlignment.end,
-          children: [_buildInitialButtons()]),
-      ListView.builder(
-        padding: EdgeInsets.zero,
-        shrinkWrap: true,
-        physics: NeverScrollableScrollPhysics(),
-        itemCount: walletIdList.length,
-        itemBuilder: (context, index) {
-          return _buildWalletItem(walletIdList[index]);
-        },
-      ),
-    ]);
+    return SafeArea(
+        top: false,
+        child: ListView(padding: EdgeInsets.all(8), children: [
+          Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [_buildInitialButtons()]),
+          ListView.builder(
+            padding: EdgeInsets.zero,
+            shrinkWrap: true,
+            physics: NeverScrollableScrollPhysics(),
+            itemCount: walletIdList.length,
+            itemBuilder: (context, index) {
+              return _buildWalletItem(walletIdList[index]);
+            },
+          ),
+        ]));
   }
 }


### PR DESCRIPTION
Adds SafeArea to avoid hide content by the bottom-bar of the device.

close #106 