### PR TITLE
Fix (wallet): balance sync

### DIFF
--- a/lib/util/storage/database/wallet.dart
+++ b/lib/util/storage/database/wallet.dart
@@ -89,7 +89,7 @@ class Wallet {
   List<String> allAddresses() {
     List<String> _addresses = [];
     _addresses.addAll(addressList(KeyType.external));
-    // _addresses.addAll(addressList(KeyType.internal));
+    _addresses.addAll(addressList(KeyType.internal));
     return _addresses;
   }
 
@@ -382,7 +382,6 @@ class Wallet {
 
       /// check the current external gap between used accounts and the last empty account
       externalAccounts.forEach((key, value) {
-        // addressList.add(value.address);
         if (value.vttHashes.length > 0) {
           externalGap = 0;
         } else {


### PR DESCRIPTION
The list of addresses that is used to sync only included the external accounts. uncomment the line to add the internal accounts to the address list to sync.

Closes #127