### PR TITLE
fix(link): allow open external links in android

### DIFF
--- a/lib/widgets/link.dart
+++ b/lib/widgets/link.dart
@@ -12,10 +12,10 @@ class CustomLink extends StatelessWidget {
   });
 
   _launchUrl(String searchItem) async {
-    if (await canLaunchUrlString(url)) {
+    try {
       await launchUrlString(url);
-    } else {
-      throw 'Could not launch $url';
+    } catch (err) {
+      throw 'Could not launch $err';
     }
   }
 


### PR DESCRIPTION
This fixes the problem with `url_launcher` library and Android11.

close #146 