### PR TITLE
fix(android): multidex build issue

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -57,4 +57,5 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "com.android.support:multidex:1.0.3"
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
     package="com.witnet.myWitWallet">
    <uses-permission android:name="android.permission.INTERNET" />
    <application
-        android:name="myWitWallet"
+        android:name="${applicationName}"
         android:label="myWitWallet"
         android:icon="@mipmap/launcher_icon">
         <activity


### PR DESCRIPTION
- add multidex dependency to fix the build
- change `android:name`  from myWitWallet to  "${applicationName}" in `android/app/src/main/AndroidManifest.xml` 
   according to the [official guidelines](https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects)
