### PR TITLE
Fix: Increase External Gap Limit

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -66,7 +66,7 @@ Map<CreateWalletType, WalletType> xprvTypeToWalletType = {
   CreateWalletType.encryptedXprv: WalletType.hd,
   CreateWalletType.xprv: WalletType.single
 };
-const int EXTERNAL_GAP_LIMIT = 3;
+const int EXTERNAL_GAP_LIMIT = 10;
 const int INTERNAL_GAP_LIMIT = 3;
 const bool ENCRYPT_DB = false;
 const int PAGINATION_LIMIT = 10;


### PR DESCRIPTION
Increasing the external gap limit to 10 will match the gap limit in witnet-rust / Sheikah.

Closes #279 