### PR TITLE
feat: add support to double XPRV

### DIFF
--- a/lib/screens/create_wallet/bloc/api_create_wallet.dart
+++ b/lib/screens/create_wallet/bloc/api_create_wallet.dart
@@ -50,8 +50,7 @@ class ApiCreateWallet {
     try {
       int xprvLength = xprvString.length;
       String? xprvDecripted;
-      if (xprvLength == ENCRYPTED_XPRV_LENGTH &&
-          _xprvType == CreateWalletType.encryptedXprv) {
+      if (_xprvType == CreateWalletType.encryptedXprv) {
         xprvDecripted = await apiCrypto.decryptXprv(
             xprv: xprvString, password: password?.value ?? '');
       } else if (xprvLength == XPRV_LENGTH &&

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   worker_manager: ^4.0.2
   toml: ^0.13.1
   decimal: 2.3.2
-  witnet: 0.2.7
+  witnet: 0.3.0
   table_calendar: ^3.0.3
   qr_flutter: ^4.0.0
   window_manager: ^0.3.2


### PR DESCRIPTION
We are moving the business logic related to the XPRV length to the witnet.dart library (https://github.com/witnet/witnet.dart). So, in this PR, we only remove the XPRV length validation while importing a wallet. The logic to handle a double XPRV is implemented here: https://github.com/witnet/witnet.dart/pull/31