### PR TITLE
Feat/avoid repeated calls to explorer during sync

### DIFF
--- a/lib/shared/api_database.dart
+++ b/lib/shared/api_database.dart
@@ -271,6 +271,15 @@ class ApiDatabase {
         params: {'type': 'mint', 'value': transaction.jsonMap()});
   }
 
+  Future<ValueTransferInfo?> getVtt(String hash) async {
+    try {
+      return await _processIsolate(method: 'getVtt', params: {"hash": hash});
+    } catch (err) {
+      print('Error getting vtt:: $err');
+      return null;
+    }
+  }
+
   Future getAllVtts() async {
     try {
       return await _processIsolate(method: 'getAllVtts', params: {});

--- a/lib/shared/locator.dart
+++ b/lib/shared/locator.dart
@@ -3,6 +3,7 @@ import 'package:my_wit_wallet/screens/create_wallet/bloc/api_create_wallet.dart'
 import 'package:my_wit_wallet/bloc/crypto/api_crypto.dart';
 import 'package:my_wit_wallet/bloc/crypto/crypto_bloc.dart';
 import 'package:my_wit_wallet/util/preferences.dart';
+import 'package:my_wit_wallet/util/storage/cache/implementations/vtt_get_through_block_explorer.dart';
 import 'package:my_wit_wallet/util/storage/database/database_isolate.dart';
 import 'package:my_wit_wallet/bloc/explorer/api_explorer.dart';
 import 'package:my_wit_wallet/shared/api_database.dart';
@@ -26,6 +27,8 @@ class Locator {
       _i.registerSingleton<ApiCrypto>(ApiCrypto());
       _i.registerSingleton<CryptoIsolate>(CryptoIsolate.instance());
       _i.registerSingleton<DatabaseIsolate>(DatabaseIsolate.instance());
+      _i.registerSingleton<VttGetThroughBlockExplorer>(
+          VttGetThroughBlockExplorer());
     }
   }
 

--- a/lib/util/storage/cache/implementations/vtt_get_through_block_explorer.dart
+++ b/lib/util/storage/cache/implementations/vtt_get_through_block_explorer.dart
@@ -1,0 +1,25 @@
+import 'package:my_wit_wallet/bloc/explorer/api_explorer.dart';
+import 'package:my_wit_wallet/shared/api_database.dart';
+import 'package:my_wit_wallet/shared/locator.dart';
+import 'package:my_wit_wallet/util/storage/cache/read_through.dart';
+import 'package:witnet/explorer.dart';
+
+class VttGetThroughBlockExplorer {
+  ApiExplorer apiExplorer = Locator.instance.get<ApiExplorer>();
+  ApiDatabase db = Locator.instance.get<ApiDatabase>();
+
+  late ReadThrough<ValueTransferInfo> _vttGetThroughBlockExplorer;
+
+  VttGetThroughBlockExplorer() {
+    _vttGetThroughBlockExplorer = ReadThrough(
+      (String hash) async => await apiExplorer.hash(hash),
+      (ValueTransferInfo valueTransferInfo) async =>
+          await db.addVtt(valueTransferInfo),
+      (String hash) async => await db.getVtt(hash),
+    );
+  }
+
+  Future<ValueTransferInfo?> get(String key) async {
+    return await _vttGetThroughBlockExplorer.get(key);
+  }
+}

--- a/lib/util/storage/cache/read_through.dart
+++ b/lib/util/storage/cache/read_through.dart
@@ -1,0 +1,32 @@
+// Generic implementation of read through cache pattern
+class ReadThrough<T> {
+  // Consume the value if it's not already stored
+  Future<T?> Function(String) _fetch;
+  // Save the value in cache
+  Future<bool> Function(T) _save;
+  // Read Value from Cache
+  Future<T?> Function(String) _read;
+
+  ReadThrough(this._fetch, this._save, this._read);
+
+  Future<bool> _insert(T value) async {
+    return await _save(value);
+  }
+
+  // Check if value is stored and call the fetch function if it's not found
+  Future<T?> get(String key) async {
+    T? storedValue = await _read(key);
+
+    if (storedValue != null) {
+      return storedValue;
+    } else {
+      T? value = await _fetch(key);
+
+      if (value != null) {
+        await _insert(value);
+      }
+
+      return value;
+    }
+  }
+}

--- a/lib/util/storage/database/database_isolate.dart
+++ b/lib/util/storage/database/database_isolate.dart
@@ -17,6 +17,7 @@ Map<String, Function(DatabaseService, SendPort, Map<String, dynamic>)>
   'delete': _deleteRecord,
   'deleteDatabase': _deleteDatabase,
   'getKeychain': _getKeychain,
+  'getVtt': _getVtt,
   'loadWallets': _getAllWallets,
   'lock': _lock,
   'masterKeySet': _masterKeySet,
@@ -227,4 +228,13 @@ Future<void> _getKeychain(
 ) async {
   await dbService.getKey();
   port.send(dbService.keyChain.keyHash);
+}
+
+Future<void> _getVtt(
+  DatabaseService dbService,
+  SendPort port,
+  Map<String, dynamic> params,
+) async {
+  ValueTransferInfo? vtt = await dbService.getVtt(params);
+  port.send(vtt);
 }

--- a/lib/util/storage/database/database_isolate.dart
+++ b/lib/util/storage/database/database_isolate.dart
@@ -12,17 +12,17 @@ import 'database_service.dart';
 
 Map<String, Function(DatabaseService, SendPort, Map<String, dynamic>)>
     methodMap = {
-  'configure': _configure,
   'add': _addRecord,
+  'configure': _configure,
   'delete': _deleteRecord,
   'deleteDatabase': _deleteDatabase,
-  'update': _updateRecord,
-  'setPassword': _setPassword,
-  'verifyPassword': _verifyPassword,
-  'masterKeySet': _masterKeySet,
-  'loadWallets': _getAllWallets,
   'getKeychain': _getKeychain,
+  'loadWallets': _getAllWallets,
   'lock': _lock,
+  'masterKeySet': _masterKeySet,
+  'setPassword': _setPassword,
+  'update': _updateRecord,
+  'verifyPassword': _verifyPassword,
 };
 
 class DatabaseIsolate {

--- a/lib/util/storage/database/database_service.dart
+++ b/lib/util/storage/database/database_service.dart
@@ -303,4 +303,8 @@ class DatabaseService {
     unlocked = false;
     return true;
   }
+
+  Future<ValueTransferInfo?> getVtt(params) async {
+    return await vttRepository.getTransaction(params["hash"], _database);
+  }
 }

--- a/lib/util/storage/database/transaction_repository.dart
+++ b/lib/util/storage/database/transaction_repository.dart
@@ -79,6 +79,21 @@ class VttRepository extends _TransactionRepository {
       return false;
     }
   }
+
+  Future<ValueTransferInfo?> getTransaction(
+      String txHash, DatabaseClient databaseClient) async {
+    try {
+      dynamic valueTransferInfoDbJson =
+          await _store.record(txHash).get(databaseClient);
+
+      ValueTransferInfo valueTransferInfo =
+          ValueTransferInfo.fromDbJson(valueTransferInfoDbJson);
+
+      return valueTransferInfo;
+    } catch (e) {
+      return null;
+    }
+  }
 }
 
 class DataRequestRepository extends _TransactionRepository {

--- a/test/storage/read_through_test.dart
+++ b/test/storage/read_through_test.dart
@@ -1,0 +1,64 @@
+import 'package:my_wit_wallet/util/storage/cache/read_through.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Storage implementation of read through cache pattern in memory', () {
+    test('Should call fetch callback if it\'s first time getting the value',
+        () async {
+      int timesCalled = 0;
+      String expectedValue = "Potato";
+      bool saveCalled = false;
+
+      ReadThrough<String> cache = ReadThrough((p0) async {
+        timesCalled = timesCalled += 1;
+
+        await Future.delayed(Duration(seconds: 0));
+
+        return expectedValue;
+      }, (p1) async {
+        saveCalled = true;
+        return true;
+      }, (p0) async {
+        return null;
+      });
+
+      expect(await cache.get("whatever"), expectedValue);
+      expect(saveCalled, true);
+      expect(timesCalled, 1);
+    });
+
+    test(
+        'Should NOT call fetch callback if it\'s the second time getting the value',
+        () async {
+      int timesCalled = 0;
+      String expectedValue = "Potato";
+      bool saveCalled = false;
+
+      ReadThrough<String> cache = ReadThrough((p0) async {
+        timesCalled = timesCalled += 1;
+
+        await Future.delayed(Duration(seconds: 0));
+
+        return expectedValue;
+      }, (p1) async {
+        saveCalled = true;
+        return true;
+      }, (p0) async {
+        if (timesCalled == 0) {
+          return null;
+        } else {
+          return expectedValue;
+        }
+      });
+
+      // call get multiple times
+      expect(await cache.get(expectedValue), expectedValue);
+      expect(await cache.get(expectedValue), expectedValue);
+      expect(await cache.get(expectedValue), expectedValue);
+      expect(await cache.get(expectedValue), expectedValue);
+      expect(saveCalled, true);
+
+      expect(timesCalled, 1);
+    });
+  });
+}


### PR DESCRIPTION
During the synchronization process, the wallet was calling multiple times to the hash endpoint of the Witnet Block Explorer. It occurred when the user had multiple accounts and had sent funds between them. During the wallet synchronization, if two accounts of the same wallet had sent funds between them, both would call the explorer with the same hash of a valueTransferOutput. Because of that, the number of repeated calls relied on the number of times accounts of the same wallet have interacted between them.

To avoid multiple calls, we have implemented an in-memory cache using a "read through" pattern to fetch the Witnet Block Explorer API only if it wasn't called before.