### PR TITLE
fix(signTransaction): avoid using biometrics to unlock the wallet

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -359,12 +359,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "Apple Distribution: Witnet Foundation (SENSITIVE_REPLACE_ME)";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution: Witnet Foundation (SENSITIVE_REPLACE_ME)";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = SENSITIVE_REPLACE_ME;
+				DEVELOPMENT_TEAM = 8X9KVU28PX;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -372,10 +370,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0;
-				PRODUCT_BUNDLE_IDENTIFIER = io.witnet.myWitWallet;
+				PRODUCT_BUNDLE_IDENTIFIER = io.witnet.myWitWallett;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore io.witnet.myWitWallet";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -443,11 +440,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "Apple Distribution: Witnet Foundation (SENSITIVE_REPLACE_ME)";
+				CODE_SIGN_IDENTITY = "Apple Distribution: Witnet Foundation (8X9KVU28PX)";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 0;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = SENSITIVE_REPLACE_ME;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8X9KVU28PX;
 				ENABLE_BITCODE = NO;
 				FLUTTER_APPLICATION_PATH = /Users/gabaldon/Witnet/witnet_wallet;
 				FLUTTER_BUILD_DIR = build;
@@ -461,10 +458,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0;
-				PRODUCT_BUNDLE_IDENTIFIER = io.witnet.myWitWallet;
+				PRODUCT_BUNDLE_IDENTIFIER = io.witnet.myWitWallett;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore io.witnet.myWitWallet";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore io.witnet.myWitWallett";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -555,7 +552,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution: Witnet Foundation (SENSITIVE_REPLACE_ME)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution: Witnet Foundation (8X9KVU28PX)";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
@@ -585,11 +582,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "Apple Distribution: Witnet Foundation (SENSITIVE_REPLACE_ME)";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = SENSITIVE_REPLACE_ME;
+				DEVELOPMENT_TEAM = 8X9KVU28PX;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -597,10 +593,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0;
-				PRODUCT_BUNDLE_IDENTIFIER = io.witnet.myWitWallet;
+				PRODUCT_BUNDLE_IDENTIFIER = io.witnet.myWitWallett;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore io.witnet.myWitWallet";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -614,12 +609,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "Apple Distribution: Witnet Foundation (SENSITIVE_REPLACE_ME)";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution: Witnet Foundation (SENSITIVE_REPLACE_ME)";
+				CODE_SIGN_IDENTITY = "Apple Distribution: Witnet Foundation (8X9KVU28PX)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution: Witnet Foundation (8X9KVU28PX)";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = SENSITIVE_REPLACE_ME;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8X9KVU28PX;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -627,10 +622,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0;
-				PRODUCT_BUNDLE_IDENTIFIER = io.witnet.myWitWallet;
+				PRODUCT_BUNDLE_IDENTIFIER = io.witnet.myWitWallett;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore io.witnet.myWitWallet";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore io.witnet.myWitWallett";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,8 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSCameraUsageDescription</key>
-	<string>This app needs camera access to scan QR codes</string>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -24,7 +24,15 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>This app needs camera access to scan QR codes</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Why is my app authenticating using face id?</string>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
@@ -45,13 +53,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
-	<key>NSFaceIDUsageDescription</key>
-	<string>Why is my app authenticating using face id?</string>
 </dict>
 </plist>

--- a/lib/screens/login/view/login_form.dart
+++ b/lib/screens/login/view/login_form.dart
@@ -152,7 +152,6 @@ class LoginFormState extends State<LoginForm> with TickerProviderStateMixin {
             crossAxisAlignment: CrossAxisAlignment.center,
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              showBiometrics() ? BiometricsAutentication() : Container(),
               SizedBox(height: 8),
               ReEstablishWalletBtn(),
             ])

--- a/lib/screens/login/view/login_form.dart
+++ b/lib/screens/login/view/login_form.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:my_wit_wallet/screens/login/view/biometrics_autentication.dart';
 import 'package:my_wit_wallet/screens/login/view/re_establish_wallet_button.dart';
-import 'package:my_wit_wallet/util/allow_biometrics.dart';
 import 'package:my_wit_wallet/widgets/layouts/layout.dart';
 import 'package:my_wit_wallet/widgets/input_login.dart';
 import 'package:my_wit_wallet/widgets/PaddedButton.dart';


### PR DESCRIPTION
Avoid using biometrics to unlock the wallet to be able to correctly sign transactions. 

Signing transactions needs the password hash to decrypt the xprv, either we delete the biometrics functionality or ask the user to input the password to send transactions #379 . Using a switch in settings to enable using biometrics cannot be an option as the library `local_auth` does not return a unique identifier to encrypt the xprv.

close #374