### PR TITLE
fix: avoid warning when going from miner fee step to review step

### DIFF
--- a/lib/widgets/witnet/transactions/value_transfer/create_dialog_box/vtt_builder/02_select_miner_fee.dart
+++ b/lib/widgets/witnet/transactions/value_transfer/create_dialog_box/vtt_builder/02_select_miner_fee.dart
@@ -258,6 +258,7 @@ class SelectMinerFeeStepState extends State<SelectMinerFeeStep>
                 _minerFeeFocusNode.requestFocus();
               },
               onFieldSubmitted: (String value) {
+                FocusManager.instance.primaryFocus?.unfocus();
                 widget.goNext();
               },
               onEditingComplete: () {


### PR DESCRIPTION
This warning appeared every time the user go to the next step having the keyboard open in i0S:
```
[LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want.
	Try this:
		(1) look at each constraint and try to figure out which you don't expect;
		(2) find the code that added the unwanted constraint or constraints and fix it.
(
    "<NSLayoutConstraint:0x281e81db0 'assistantHeight' SystemInputAssistantView.height == 44   (active, names: SystemInputAssistantView:0x12962dc20 )>",
    "<NSLayoutConstraint:0x281eccdc0 'assistantView.bottom' SystemInputAssistantView.bottom == _UIKBCompatInputView:0x127e1c7d0.top   (active, names: SystemInputAssistantView:0x12962dc20 )>",
    "<NSLayoutConstraint:0x281ecfa20 'assistantView.top' V:|-(0)-[SystemInputAssistantView]   (active, names: SystemInputAssistantView:0x12962dc20, '|':UIInputSetHostView:0x127ef4d00 )>",
    "<NSLayoutConstraint:0x281e87f70 'inputView.top' V:|-(0)-[_UIKBCompatInputView:0x127e1c7d0]   (active, names: '|':UIInputSetHostView:0x127ef4d00 )>"
)
```

The warning disappeared hiding the keyboard when validating the form.