### PR TITLE
feat: add signMessage method

### DIFF
--- a/lib/bloc/crypto/crypto_bloc.dart
+++ b/lib/bloc/crypto/crypto_bloc.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:isolate';
+import 'dart:typed_data';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -11,6 +12,7 @@ import 'package:witnet/constants.dart';
 import 'package:witnet/crypto.dart';
 import 'package:witnet/explorer.dart';
 import 'package:witnet/schema.dart';
+import 'package:witnet/utils.dart';
 import 'package:witnet/witnet.dart';
 import 'package:my_wit_wallet/constants.dart';
 import 'package:my_wit_wallet/screens/create_wallet/bloc/api_create_wallet.dart';


### PR DESCRIPTION
- add method in crypto_isolate.dart to sign a message
- add wrapper in api_crypto.dart to call the isolate method

to call the method from anywhere in myWitWallet after the wallet is unlocked:
`Map<String, dynamic> signedMessage = await Locator.instance.get<ApiCrypto>().signMessage("Hello World", "wit1...");`