### PR TITLE
chore: delete `x86` from android build config

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -46,7 +46,7 @@ android {
         multiDexEnabled true
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        ndk { abiFilters "arm64-v8a", "armeabi-v7a", "x86", "x86_64" }
+        ndk { abiFilters "arm64-v8a", "armeabi-v7a", "x86_64" }
     }
 
     signingConfigs {


### PR DESCRIPTION
Flutter does not support `x86` architecture. Check [supported architectures for android.](https://docs.flutter.dev/deployment/android#what-are-the-supported-target-architectures)
Check [issue](https://github.com/flutter/flutter/issues/37396#issuecomment-1207203921) in flutter.