### PR TITLE
ci(windows): set dotnet-version v8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Setup Microsoft Store Developer CLI
         uses: microsoft/setup-msstore-cli@v1
 
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Configure Microsoft Store Developer CLI
         run: |
           (Get-Content pubspec.yaml).replace('<REAL_CN>', "${{ secrets.CN }}") | Set-Content pubspec.yaml


### PR DESCRIPTION
By default, the setup task picks up the latest version of the tool, and it just got updated with dotnet 8. You have to add the setup dotnet task before this task:
```yaml
- uses: actions/setup-dotnet@v3
  with:
    dotnet-version: '8.0.x'
```
The agents haven't been updated yet, so you need this until they have it installed by default.

_Originally posted by @azchohfi in https://github.com/microsoft/setup-msstore-cli/issues/133#issuecomment-1815881944_