### PR TITLE
feat: add transaction sync to BlocEvent

### DIFF
--- a/lib/bloc/crypto/crypto_state.dart
+++ b/lib/bloc/crypto/crypto_state.dart
@@ -14,26 +14,20 @@ class CryptoReadyState extends CryptoState {
 class CryptoInitializingWalletState extends CryptoState {
   final String message;
 
-  final int availableNanoWit;
-  final int lockedNanoWit;
+  final BalanceInfo balanceInfo;
   final int transactionCount;
   final int addressCount;
 
-  CryptoInitializingWalletState(
-      {required this.message,
-      required this.availableNanoWit,
-      required this.lockedNanoWit,
-      required this.transactionCount,
-      required this.addressCount});
+  CryptoInitializingWalletState({
+    required this.message,
+    required this.balanceInfo,
+    required this.transactionCount,
+    required this.addressCount,
+  });
 
   @override
-  List<Object?> get props => [
-        message,
-        availableNanoWit,
-        lockedNanoWit,
-        transactionCount,
-        addressCount
-      ];
+  List<Object?> get props =>
+      [message, balanceInfo, transactionCount, addressCount];
 }
 
 class CryptoLoadedWalletState extends CryptoState {

--- a/lib/bloc/explorer/api_explorer.dart
+++ b/lib/bloc/explorer/api_explorer.dart
@@ -179,8 +179,6 @@ class ApiExplorer {
           rethrow;
         }
       }
-
-      account.setBalance();
     } catch (e) {
       print('Error updating account vtts and balance $e');
       rethrow;

--- a/lib/bloc/explorer/explorer_bloc.dart
+++ b/lib/bloc/explorer/explorer_bloc.dart
@@ -399,7 +399,6 @@ class ExplorerBloc extends Bloc<ExplorerEvent, ExplorerState> {
       if (account.keyType == KeyType.master) {
         await _syncAccountMints(account);
       }
-      await account.setBalance();
       database.walletStorage.wallets[account.walletId]!.setAccount(account);
     } catch (e) {
       print('Error updating account vtts and balance $e');
@@ -416,7 +415,7 @@ class ExplorerBloc extends Bloc<ExplorerEvent, ExplorerState> {
       Account? account = wallet.accountByAddress(address);
       if (account != null && !account.sameUtxoList(utxoList)) {
         if (utxoList.isNotEmpty) {
-          account.utxos = utxoList;
+          account.updateUtxos(utxoList);
           account = await syncAccountVttsAndBalance(account);
         } else {
           account.utxos.clear();

--- a/lib/screens/create_wallet/build_wallet_card.dart
+++ b/lib/screens/create_wallet/build_wallet_card.dart
@@ -13,6 +13,7 @@ import 'package:my_wit_wallet/screens/dashboard/view/dashboard_screen.dart';
 import 'package:my_wit_wallet/screens/login/bloc/login_bloc.dart';
 import 'package:my_wit_wallet/screens/login/view/init_screen.dart';
 import 'package:my_wit_wallet/shared/locator.dart';
+import 'package:my_wit_wallet/util/storage/database/wallet.dart';
 import 'package:my_wit_wallet/widgets/animated_numeric_text.dart';
 import 'package:my_wit_wallet/widgets/auto_size_text.dart';
 import 'package:my_wit_wallet/widgets/layouts/dashboard_layout.dart';
@@ -292,22 +293,24 @@ class BuildWalletCardState extends State<BuildWalletCard>
                   )
                 ],
               ),
-              Row(
-                children: [
-                  AutoSizeText(
-                    localization.exploredAddresses,
-                    maxLines: 2,
-                    minFontSize: 16,
-                  ),
-                  AnimatedIntegerText(
-                      initialValue: currentAddressCount,
-                      // TODO:targetValue: addressCount,
-                      targetValue: currentAddressCount,
-                      curve: Interval(0, .5, curve: Curves.easeOut),
-                      controller: _balanceController,
-                      style: theme.textTheme.headlineSmall!)
-                ],
-              ),
+              if (Locator.instance<ApiCreateWallet>().walletType ==
+                  WalletType.hd)
+                Row(
+                  children: [
+                    AutoSizeText(
+                      localization.exploredAddresses,
+                      maxLines: 2,
+                      minFontSize: 16,
+                    ),
+                    AnimatedIntegerText(
+                        initialValue: currentAddressCount,
+                        // TODO:targetValue: addressCount,
+                        targetValue: currentAddressCount,
+                        curve: Interval(0, .5, curve: Curves.easeOut),
+                        controller: _balanceController,
+                        style: theme.textTheme.headlineSmall!)
+                  ],
+                ),
               SizedBox(
                 height: 20,
               ),

--- a/lib/screens/create_wallet/build_wallet_card.dart
+++ b/lib/screens/create_wallet/build_wallet_card.dart
@@ -49,6 +49,9 @@ class BuildWalletCardState extends State<BuildWalletCard>
   int currentTransactionCount = 0;
   static const headerAniInterval = Interval(.1, .3, curve: Curves.easeOut);
 
+  bool get isHdWallet =>
+      Locator.instance<ApiCreateWallet>().walletType == WalletType.hd;
+
   void prevAction() {
     CreateWalletType type =
         BlocProvider.of<CreateWalletBloc>(context).state.createWalletType;
@@ -171,7 +174,7 @@ class BuildWalletCardState extends State<BuildWalletCard>
       _balanceController.reset();
       _balanceController.forward();
       previousBalance = balance;
-      balance = state.availableNanoWit;
+      balance = state.balanceInfo.availableNanoWit;
       currentAddressCount = state.addressCount;
       currentTransactionCount = state.transactionCount;
     });
@@ -232,7 +235,7 @@ class BuildWalletCardState extends State<BuildWalletCard>
                   theme: theme,
                   addressCount: state.addressCount,
                   startingBalance: previousBalance,
-                  balanceNanoWit: state.availableNanoWit,
+                  balanceNanoWit: state.balanceInfo.availableNanoWit,
                   transactionCount: state.transactionCount,
                   message: state.message),
               SizedBox(
@@ -293,8 +296,7 @@ class BuildWalletCardState extends State<BuildWalletCard>
                   )
                 ],
               ),
-              if (Locator.instance<ApiCreateWallet>().walletType ==
-                  WalletType.hd)
+              if (isHdWallet)
                 Row(
                   children: [
                     AutoSizeText(

--- a/lib/util/storage/database/balance_info.dart
+++ b/lib/util/storage/database/balance_info.dart
@@ -3,8 +3,8 @@ import 'package:witnet/constants.dart';
 import 'package:witnet/data_structures.dart';
 
 class BalanceInfo {
-  late final int availableNanoWit;
-  late final int lockedNanoWit;
+  int availableNanoWit;
+  int lockedNanoWit;
   List<Utxo> availableUtxos;
   List<Utxo> lockedUtxos;
   BalanceInfo({
@@ -14,6 +14,10 @@ class BalanceInfo {
     required this.lockedUtxos,
   })  : this.availableNanoWit = availableNanoWIT,
         this.lockedNanoWit = lockedNanoWIT;
+
+  factory BalanceInfo.zero() {
+    return BalanceInfo(availableUtxos: [], lockedUtxos: []);
+  }
 
   factory BalanceInfo.fromUtxoList(List<Utxo> utxos) {
     int _lockedNanoWit = 0;

--- a/lib/util/storage/database/database_service.dart
+++ b/lib/util/storage/database/database_service.dart
@@ -295,12 +295,6 @@ class DatabaseService {
               return DBException(code: e.hashCode, message: '$e');
             }
           }
-          try {
-            /// Set the account balance since the transactions are set.
-            await accounts[i].setBalance();
-          } catch (e) {
-            return DBException(code: e.hashCode, message: '$e');
-          }
 
           /// Add the account to the wallet
           if (walletMap[_walletId] != null) {

--- a/lib/util/storage/database/wallet.dart
+++ b/lib/util/storage/database/wallet.dart
@@ -47,16 +47,8 @@ class Wallet {
     required this.externalAccounts,
     required this.internalAccounts,
     this.lastSynced = -1,
-  }) {
-    this.id = '00000000';
-    this.externalAccounts.forEach((key, Account account) {
-      account.setBalance();
-    });
-
-    this.internalAccounts.forEach((key, Account account) {
-      account.setBalance();
-    });
-  }
+    this.id = "00000000",
+  });
 
   final WalletType walletType;
   late String id;


### PR DESCRIPTION
- emit `CryptoInitializingWalletState` for every transaction during the initial sync.
- only display `localization.exploredAddresses` for hd wallets

Closes #451